### PR TITLE
feat: add kaggle data downloader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Data format
 *.csv
+input/
 
 ###Python###
 

--- a/README.md
+++ b/README.md
@@ -23,5 +23,34 @@ Please see k0-00-template.ipynb
 * results
 * future work and exercises
 
+## Kaggle Utils
+* `kaggle_download.py`
+    1. Fill out your `username` and `password` in kaggle.ini
+    2. Accept the agreement term in Kaggle website by clicking any button like submit predictions or download a dataset
+    3. Find out a competition name
+        * Competition name can be found in the URL
+        * For example, if the url is `https://www.kaggle.com/c/digit-recognizer`,  
+          then the competition name is `digit-recognizer`
+    3. Run the following command in bash to download a dataset
+    ```bash
+    # python kaggle_download.py `competition-name` --destination `path/to/save/dataset`
+    # Example
+    $ python kaggle_download.py digit-recognizer --destination k0-01-mnist/input
+    ```
+    * `python -h`
+    ```bash
+    usage: kaggle_download.py [-h] [--destination DESTINATION] competition
+
+    positional arguments:
+      competition           name of competition. For example, if the URL is
+                            http://www.kaggle.com/c/digit-recognizer then enter
+                            digit-recognizer
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      --destination DESTINATION
+                            local path for datasets to be downloaded (default: ./)
+    ```
+
  ## Contributions
  We welcome any contributions including writing issues and sending pull requests.

--- a/kaggle.ini
+++ b/kaggle.ini
@@ -1,0 +1,3 @@
+[account]
+username=KAGGLE@KAGGLE.COM
+password=KAGGLE_PASSWORD

--- a/kaggle_download.py
+++ b/kaggle_download.py
@@ -1,0 +1,119 @@
+"""
+Kaggle Download Dataset Wrapper
+
+Examples
+----------
+$ python kaggle_download.py {competition-name} --destination {destination}
+$ python kaggle_download.py digit-recognizer --destination k0-01-mnist/input
+
+"""
+import configparser
+import bs4
+import requests
+import re
+import os
+import argparse
+from multiprocessing import pool
+from urllib.parse import urljoin
+
+
+def login(username, password):
+    session = requests.session()
+    login_info = {"UserName": username, "Password": password}
+    session.post("https://www.kaggle.com/account/login?ReturnUrl=kaggle.com", login_info)
+
+    return session
+
+
+def download(url, session, destination):
+    r = session.post(url)
+    local_filename = os.path.join(destination, url.split('/')[-1])
+
+    # Writes the data to a local file one chunk at a time.
+    with open(local_filename, 'wb') as f:
+        total_length = r.headers.get('content-length')
+        content_type = r.headers.get('Content-Type', '')
+        content_disp = r.headers.get('Content-Disposition', '')
+
+        if 'text/html' in content_type and 'attachment' not in content_disp:
+            print(f"Please accept the agreement terms by going to {url}")
+            return False
+        if total_length is None:  # no content length header
+            f.write(r.content)
+
+        else:
+
+            dl = 0
+            total_length = int(total_length)
+
+            for data in r.iter_content(chunk_size=4096):
+                f.write(data)
+
+                dl += len(data)
+                done = int(50 * dl / total_length)
+
+                print(f"[{'=' * done}{' ' * (50 - done)}] {local_filename}", flush=True, end='\r')
+
+            print()
+
+
+def get_data_url_by_name(competition):
+    base_url = "http://www.kaggle.com/"
+    url = urljoin(base_url, f"c/{competition}/data")
+    r = requests.get(url)
+    bs = bs4.BeautifulSoup(r.text, 'html.parser')
+    filenames = re.findall('"url":"(/c/{}/download/[^"]+)"'.format(competition), bs.text)
+    filenames = [urljoin(base_url, f) for f in filenames]
+    return filenames
+
+
+def read_config(file='kaggle.ini'):
+    parser = configparser.ConfigParser()
+    parser.read(file)
+    username = parser.get('account', 'username')
+    password = parser.get('account', 'password')
+
+    return username, password
+
+
+def read_args():
+    def check_destination(path):
+        os.makedirs(path, exist_ok=True)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("competition",
+                        help="name of competition. For example, if the URL is http://www.kaggle.com/c/digit-recognizer then enter digit-recognizer")
+    parser.add_argument("--destination", default='.',
+                        help="local path for datasets to be downloaded (default: ./)")
+    args = parser.parse_args()
+
+    competition = args.competition
+    destination = args.destination
+    check_destination(destination)
+
+    return competition, destination
+
+
+def run_download(fn, args):
+    return fn(*args)
+
+
+def run_star(args):
+    return run_download(*args)
+
+
+if __name__ == '__main__':
+
+    competition, destination = read_args()
+    username, password = read_config()
+
+    if username == "KAGGLE@KAGGLE.COM" or password == "KAGGLE_PASSWORD":
+        print("Please setup kaggle.ini first")
+
+    else:
+        session = login(username, password)
+        data_url_list = get_data_url_by_name(competition)
+
+        pool = pool.Pool()
+        tasks = [(download, (url, session, destination)) for url in data_url_list]
+        results = pool.map_async(run_star, tasks)
+        results.wait()

--- a/kaggle_submit.py
+++ b/kaggle_submit.py
@@ -1,0 +1,81 @@
+"""
+Kaggle Submission Dataset Wrapper
+
+Examples
+----------
+$ python kaggle_submit.py {competition-name} {submission-file} -m {message}
+$ python kaggle_submit.py digit-recognizer k0-01-mnist/submission.csv -m "First Submission"
+
+"""
+import configparser
+import bs4
+import requests
+import argparse
+
+from urllib.parse import urljoin
+
+
+def login(username, password):
+    session = requests.session()
+    login_info = {"UserName": username, "Password": password}
+    session.post("https://www.kaggle.com/account/login?ReturnUrl=kaggle.com", login_info)
+
+    return session
+
+
+def read_config(file='kaggle.ini'):
+    parser = configparser.ConfigParser()
+    parser.read(file)
+    username = parser.get('account', 'username')
+    password = parser.get('account', 'password')
+
+    return username, password
+
+
+def read_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("competition",
+                        help="name of competition. For example, if the URL is http://www.kaggle.com/c/digit-recognizer then enter digit-recognizer")
+    parser.add_argument("submission",
+                        help="submission file")
+
+    parser.add_argument("-m", "--message", help="submission message")
+    args = parser.parse_args()
+
+    competition = args.competition
+    submission = args.submission
+    message = args.message
+    return competition, submission, message
+
+
+def upload(competition, session, file, message=None):
+    upload_URL = f"https://www.kaggle.com/c/{competition}/submissions/attach"
+    submit_URL = urljoin(upload_URL, "/competitions/submissions/accept")
+
+    bs = bs4.BeautifulSoup(session.get(upload_URL).text, 'lxml')
+    token = bs.find('input', attrs={"name": "__RequestVerificationToken"})['value']
+    competition_id = bs.find('input', attrs={"id": "CompetitionId"})['value']
+
+    input_data = {
+        "__RequestVerificationToken": token,
+        "CompetitionId": competition_id,
+        "SubmissionDescription": message,
+        "IsScriptVersionSubmission": False,
+    }
+
+    with open(file, 'rb') as f:
+        files = {"SubmissionUpload": f}
+        return session.post(submit_URL, files=files, data=input_data)
+
+
+if __name__ == '__main__':
+    username, password = read_config()
+
+    if username == "KAGGLE@KAGGLE.COM" or password == "KAGGLE_PASSWORD":
+        print("Please setup kaggle.ini first")
+
+    else:
+        session = login(username, password)
+        competition_name, submission_file, message = read_args()
+        res = upload(competition_name, session, submission_file, message)
+        print(f"Uploaded: https://www.kaggle.com/c/{competition_name}/submissions")


### PR DESCRIPTION
# Summary
* Add a Kaggle dataset download helper
* only tested in ubuntu with python 3.6

## How to download
1. You must accept the competition rules. This step is required only once per each competition. Currently, it cannot be done automatically. I totally forgot about this step when writing codes and I have to re-write it again to make it done automatically because I need web-browser features for this.
![competition](https://cloud.githubusercontent.com/assets/2981167/24669650/0c576a60-1920-11e7-95b8-9766e4c01834.png)
2. Grab the competition name from the URL. If the URL is `https://www.kaggle.com/c/digit-recognizer`, the competition name is `digit-recognizer`
3. Fill username and password in `kaggle.ini`
4. Run commands like
```bash
python kaggle_download.py digit-recognizer --destination k0-01-mnist/input
```
## How to submit
1. In the terminal,
```bash
python kaggle_submit.py digit-recognizer k0-01-mnist/submission.csv -m "First Submission"
```

## TODO
* [x] Add a submit command as well (should be easy)
* [ ] Add an automatic term accept feature (should be hard)
* [ ] Add test cases
 